### PR TITLE
feat: add location-based chat room system

### DIFF
--- a/src/main/java/com/tripgg/chat/controller/ChatController.java
+++ b/src/main/java/com/tripgg/chat/controller/ChatController.java
@@ -1,0 +1,131 @@
+package com.tripgg.chat.controller;
+
+import com.tripgg.chat.entity.Chat;
+import com.tripgg.chat.entity.ChatRoom;
+import com.tripgg.chat.service.ChatService;
+import com.tripgg.common.dto.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/chat")
+@RequiredArgsConstructor
+public class ChatController {
+    
+    private final ChatService chatService;
+    
+    /**
+     * 채팅방 조회 (roomId와 위경도 매칭 필요)
+     * GET /api/chat/{roomId}
+     */
+    @GetMapping("/{roomId}")
+    public ResponseEntity<ApiResponse<ChatRoom>> getChatRoom(
+            @PathVariable Integer roomId,
+            @RequestParam Double latitude,
+            @RequestParam Double longitude) {
+        
+        log.info("채팅방 조회: roomId={}, 위도={}, 경도={}", roomId, latitude, longitude);
+        
+        try {
+            ChatRoom chatRoom = chatService.getChatRoomWithLocationCheck(roomId, latitude, longitude);
+            if (chatRoom == null) {
+                return ResponseEntity.ok(ApiResponse.success("해당 위치에서 접근할 수 없는 채팅방입니다.", null));
+            }
+            return ResponseEntity.ok(ApiResponse.success("채팅방을 성공적으로 조회했습니다.", chatRoom));
+        } catch (Exception e) {
+            log.error("채팅방 조회 실패: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(ApiResponse.error("채팅방 조회에 실패했습니다."));
+        }
+    }
+    
+    /**
+     * 메시지 조회 (사용자 위치 좌표값으로 채팅방 확인)
+     * GET /api/chat/{roomId}/messages
+     */
+    @GetMapping("/{roomId}/messages")
+    public ResponseEntity<ApiResponse<List<Chat>>> getChatRoomMessages(
+            @PathVariable Integer roomId,
+            @RequestParam Double latitude,
+            @RequestParam Double longitude) {
+        
+        log.info("채팅방 메시지 조회: roomId={}, 위도={}, 경도={}", roomId, latitude, longitude);
+        
+        try {
+            List<Chat> chats = chatService.getChatRoomMessagesWithLocationCheck(roomId, latitude, longitude);
+            if (chats == null) {
+                return ResponseEntity.ok(ApiResponse.success("해당 위치에서 접근할 수 없는 채팅방입니다.", null));
+            }
+            return ResponseEntity.ok(ApiResponse.success("채팅방 메시지를 성공적으로 조회했습니다.", chats));
+        } catch (Exception e) {
+            log.error("채팅방 메시지 조회 실패: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(ApiResponse.error("채팅방 메시지 조회에 실패했습니다."));
+        }
+    }
+    
+    /**
+     * 메시지 전송 (사용자 위치 조회 후 위치 벗어나면 안 보내지도록)
+     * POST /api/chat/{roomId}/messages/send
+     */
+    @PostMapping("/{roomId}/messages/send")
+    public ResponseEntity<ApiResponse<Chat>> sendMessage(
+            @PathVariable Integer roomId,
+            @RequestParam String message,
+            @RequestParam Double latitude,
+            @RequestParam Double longitude) {
+        
+        log.info("메시지 전송: roomId={}, 위도={}, 경도={}, message={}", roomId, latitude, longitude, message);
+        
+        try {
+            Chat chat = chatService.sendMessageWithLocationCheck(roomId, message, latitude, longitude);
+            return ResponseEntity.ok(ApiResponse.success("메시지를 성공적으로 전송했습니다.", chat));
+        } catch (Exception e) {
+            log.error("메시지 전송 실패: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(ApiResponse.error("메시지 전송에 실패했습니다."));
+        }
+    }
+    
+    /**
+     * 채팅방 생성 (관리자용) - 테스트용 서울/부산 채팅방
+     * POST /api/chat/room/create
+     */
+    @PostMapping("/room/create")
+    public ResponseEntity<ApiResponse<ChatRoom>> createChatRoom(
+            @RequestParam String roomName,
+            @RequestParam Double latitude,
+            @RequestParam Double longitude,
+            @RequestParam String locationName,
+            @RequestParam Double radiusKm) {
+        
+        log.info("새 채팅방 생성: {} (위도={}, 경도={}, 지역={})", roomName, latitude, longitude, locationName);
+        
+        try {
+            ChatRoom chatRoom = chatService.createChatRoom(roomName, latitude, longitude, locationName, radiusKm);
+            return ResponseEntity.ok(ApiResponse.success("채팅방을 성공적으로 생성했습니다.", chatRoom));
+        } catch (Exception e) {
+            log.error("채팅방 생성 실패: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(ApiResponse.error("채팅방 생성에 실패했습니다."));
+        }
+    }
+    
+    /**
+     * 모든 채팅방 목록 조회 (테스트용)
+     * GET /api/chat/rooms
+     */
+    @GetMapping("/rooms")
+    public ResponseEntity<ApiResponse<List<ChatRoom>>> getAllChatRooms() {
+        log.info("모든 채팅방 조회");
+        
+        try {
+            List<ChatRoom> chatRooms = chatService.getAllActiveChatRooms();
+            return ResponseEntity.ok(ApiResponse.success("모든 채팅방을 성공적으로 조회했습니다.", chatRooms));
+        } catch (Exception e) {
+            log.error("채팅방 목록 조회 실패: {}", e.getMessage());
+            return ResponseEntity.badRequest().body(ApiResponse.error("채팅방 목록 조회에 실패했습니다."));
+        }
+    }
+}

--- a/src/main/java/com/tripgg/chat/entity/Chat.java
+++ b/src/main/java/com/tripgg/chat/entity/Chat.java
@@ -28,6 +28,10 @@ public class Chat {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
     
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_room_id", nullable = false)
+    private ChatRoom chatRoom;
+    
     @Column(name = "message", columnDefinition = "TEXT")
     private String message;
     

--- a/src/main/java/com/tripgg/chat/entity/ChatRoom.java
+++ b/src/main/java/com/tripgg/chat/entity/ChatRoom.java
@@ -1,0 +1,47 @@
+package com.tripgg.chat.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "chat_rooms")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@EntityListeners(AuditingEntityListener.class)
+public class ChatRoom {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+    
+    @Column(name = "room_name", nullable = false)
+    private String roomName;  // 예: "서울 채팅방", "부산 채팅방"
+    
+    @Column(name = "latitude", nullable = false)
+    private Double latitude;  // 채팅방 중심 위도
+    
+    @Column(name = "longitude", nullable = false)
+    private Double longitude; // 채팅방 중심 경도
+    
+    @Column(name = "location_name", nullable = false)
+    private String locationName; // 예: "서울", "부산"
+    
+    @Column(name = "radius_km", nullable = false)
+    private Double radiusKm;  // 채팅방 반경 (km)
+    
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive; // 채팅방 활성화 상태
+    
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/tripgg/chat/repository/ChatRepository.java
+++ b/src/main/java/com/tripgg/chat/repository/ChatRepository.java
@@ -1,0 +1,29 @@
+package com.tripgg.chat.repository;
+
+import com.tripgg.chat.entity.Chat;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ChatRepository extends JpaRepository<Chat, Integer> {
+    
+    /**
+     * 특정 채팅방의 메시지 조회
+     */
+    List<Chat> findByChatRoomIdOrderByCreatedAtDesc(Integer chatRoomId);
+    
+    /**
+     * 특정 지역의 채팅방 메시지 조회
+     */
+    @Query("SELECT c FROM Chat c WHERE c.chatRoom.locationName = :locationName ORDER BY c.createdAt DESC")
+    List<Chat> findChatsByLocationName(@Param("locationName") String locationName);
+    
+    /**
+     * 사용자가 참여한 채팅방 조회
+     */
+    List<Chat> findByUserIdOrderByCreatedAtDesc(Long userId);
+}

--- a/src/main/java/com/tripgg/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/tripgg/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,55 @@
+package com.tripgg.chat.repository;
+
+import com.tripgg.chat.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Integer> {
+    
+    /**
+     * 사용자 위치에서 가장 가까운 채팅방 찾기
+     * 위도, 경도 범위 내의 활성화된 채팅방을 조회
+     */
+    @Query("SELECT cr FROM ChatRoom cr WHERE " +
+           "cr.isActive = true AND " +
+           "cr.latitude BETWEEN :minLat AND :maxLat AND " +
+           "cr.longitude BETWEEN :minLng AND :maxLng " +
+           "ORDER BY " +
+           "SQRT(POWER(cr.latitude - :userLat, 2) + POWER(cr.longitude - :userLng, 2)) ASC")
+    List<ChatRoom> findNearestChatRooms(
+        @Param("userLat") Double userLat,
+        @Param("userLng") Double userLng,
+        @Param("minLat") Double minLat,
+        @Param("maxLat") Double maxLat,
+        @Param("minLng") Double minLng,
+        @Param("maxLng") Double maxLng
+    );
+    
+    /**
+     * 특정 지역의 채팅방 찾기
+     */
+    Optional<ChatRoom> findByLocationNameAndIsActiveTrue(String locationName);
+    
+    /**
+     * 활성화된 모든 채팅방 조회
+     */
+    List<ChatRoom> findByIsActiveTrue();
+    
+    /**
+     * 특정 좌표에서 반경 내 채팅방 찾기
+     */
+    @Query("SELECT cr FROM ChatRoom cr WHERE " +
+           "cr.isActive = true AND " +
+           "SQRT(POWER(cr.latitude - :latitude, 2) + POWER(cr.longitude - :longitude, 2)) <= :radiusKm")
+    List<ChatRoom> findChatRoomsWithinRadius(
+        @Param("latitude") Double latitude,
+        @Param("longitude") Double longitude,
+        @Param("radiusKm") Double radiusKm
+    );
+}

--- a/src/main/java/com/tripgg/chat/service/ChatService.java
+++ b/src/main/java/com/tripgg/chat/service/ChatService.java
@@ -1,0 +1,217 @@
+package com.tripgg.chat.service;
+
+import com.tripgg.chat.entity.Chat;
+import com.tripgg.chat.entity.ChatRoom;
+import com.tripgg.chat.repository.ChatRepository;
+import com.tripgg.chat.repository.ChatRoomRepository;
+import com.tripgg.user.entity.User;
+import com.tripgg.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChatService {
+    
+    private final ChatRepository chatRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final UserRepository userRepository;
+    
+    /**
+     * 사용자 위치에서 가장 가까운 채팅방 찾기
+     */
+    public ChatRoom findNearestChatRoom(Double userLat, Double userLng) {
+        // 위도 1도 = 약 111km, 경도 1도 = 약 111km * cos(위도)
+        double searchRadius = 50.0; // 50km 반경에서 검색
+        double latDelta = searchRadius / 111.0;
+        double lngDelta = searchRadius / (111.0 * Math.cos(Math.toRadians(userLat)));
+        
+        double minLat = userLat - latDelta;
+        double maxLat = userLat + latDelta;
+        double minLng = userLng - lngDelta;
+        double maxLng = userLng + lngDelta;
+        
+        log.info("가장 가까운 채팅방 검색: 위도({}~{}), 경도({}~{})", minLat, maxLat, minLng, maxLng);
+        
+        List<ChatRoom> nearbyRooms = chatRoomRepository.findNearestChatRooms(
+            userLat, userLng, minLat, maxLat, minLng, maxLng
+        );
+        
+        if (nearbyRooms.isEmpty()) {
+            log.warn("사용자 위치 근처에 채팅방이 없습니다: 위도={}, 경도={}", userLat, userLng);
+            return null;
+        }
+        
+        ChatRoom nearestRoom = nearbyRooms.get(0);
+        log.info("가장 가까운 채팅방: {} (위도={}, 경도={})", nearestRoom.getRoomName(), nearestRoom.getLatitude(), nearestRoom.getLongitude());
+        
+        return nearestRoom;
+    }
+    
+    /**
+     * 특정 지역의 채팅방 찾기
+     */
+    public ChatRoom getChatRoomByLocation(String locationName) {
+        log.info("지역 채팅방 조회: {}", locationName);
+        return chatRoomRepository.findByLocationNameAndIsActiveTrue(locationName)
+                .orElse(null);
+    }
+    
+    /**
+     * 특정 채팅방의 메시지 조회
+     */
+    public List<Chat> getChatRoomMessages(Integer chatRoomId) {
+        log.info("채팅방 메시지 조회: chatRoomId={}", chatRoomId);
+        return chatRepository.findByChatRoomIdOrderByCreatedAtDesc(chatRoomId);
+    }
+    
+    /**
+     * 특정 지역의 채팅방 메시지 조회
+     */
+    public List<Chat> getChatsByLocationName(String locationName) {
+        log.info("지역 채팅방 메시지 조회: {}", locationName);
+        return chatRepository.findChatsByLocationName(locationName);
+    }
+    
+    /**
+     * 사용자가 참여한 채팅방 조회
+     */
+    public List<Chat> getUserChats(Long userId) {
+        log.info("사용자 채팅방 조회: userId={}", userId);
+        return chatRepository.findByUserIdOrderByCreatedAtDesc(userId);
+    }
+    
+    /**
+     * 새 메시지 전송
+     */
+    @Transactional
+    public Chat sendMessage(Long userId, String message, Double latitude, Double longitude) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+        
+        // 사용자 위치에서 가장 가까운 채팅방 찾기
+        ChatRoom chatRoom = findNearestChatRoom(latitude, longitude);
+        if (chatRoom == null) {
+            throw new RuntimeException("사용자 위치 근처에 채팅방이 없습니다.");
+        }
+        
+        Chat chat = Chat.builder()
+                .user(user)
+                .chatRoom(chatRoom)
+                .message(message)
+                .build();
+        
+        log.info("새 메시지 전송: userId={}, chatRoom={}, message={}", userId, chatRoom.getRoomName(), message);
+        
+        return chatRepository.save(chat);
+    }
+    
+    /**
+     * 채팅방 생성 (관리자용)
+     */
+    @Transactional
+    public ChatRoom createChatRoom(String roomName, Double latitude, Double longitude, String locationName, Double radiusKm) {
+        ChatRoom chatRoom = ChatRoom.builder()
+                .roomName(roomName)
+                .latitude(latitude)
+                .longitude(longitude)
+                .locationName(locationName)
+                .radiusKm(radiusKm)
+                .isActive(true)
+                .build();
+        
+        log.info("새 채팅방 생성: {} (위도={}, 경도={})", roomName, latitude, longitude);
+        
+        return chatRoomRepository.save(chatRoom);
+    }
+    
+    /**
+     * 위치 기반 채팅방 접근 권한 확인
+     */
+    public ChatRoom getChatRoomWithLocationCheck(Integer roomId, Double userLat, Double userLng) {
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId).orElse(null);
+        if (chatRoom == null || !chatRoom.getIsActive()) {
+            return null;
+        }
+        
+        // 사용자 위치가 채팅방 반경 내에 있는지 확인
+        double distance = calculateDistance(userLat, userLng, chatRoom.getLatitude(), chatRoom.getLongitude());
+        if (distance > chatRoom.getRadiusKm()) {
+            log.warn("사용자 위치가 채팅방 반경을 벗어남: 거리={}km, 반경={}km", distance, chatRoom.getRadiusKm());
+            return null;
+        }
+        
+        log.info("채팅방 접근 권한 확인 성공: roomId={}, 거리={}km", roomId, distance);
+        return chatRoom;
+    }
+    
+    /**
+     * 위치 기반 채팅방 메시지 조회 권한 확인
+     */
+    public List<Chat> getChatRoomMessagesWithLocationCheck(Integer roomId, Double userLat, Double userLng) {
+        ChatRoom chatRoom = getChatRoomWithLocationCheck(roomId, userLat, userLng);
+        if (chatRoom == null) {
+            return null;
+        }
+        
+        return getChatRoomMessages(roomId);
+    }
+    
+    /**
+     * 위치 기반 메시지 전송 권한 확인
+     */
+    @Transactional
+    public Chat sendMessageWithLocationCheck(Integer roomId, String message, Double latitude, Double longitude) {
+        // 임시로 userId=1 사용 (테스트용)
+        Long userId = 1L;
+        
+        ChatRoom chatRoom = getChatRoomWithLocationCheck(roomId, latitude, longitude);
+        if (chatRoom == null) {
+            throw new RuntimeException("해당 위치에서 접근할 수 없는 채팅방입니다.");
+        }
+        
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+        
+        Chat chat = Chat.builder()
+                .user(user)
+                .chatRoom(chatRoom)
+                .message(message)
+                .build();
+        
+        log.info("메시지 전송 성공: roomId={}, userId={}, message={}", roomId, userId, message);
+        
+        return chatRepository.save(chat);
+    }
+    
+    /**
+     * 활성화된 모든 채팅방 조회
+     */
+    public List<ChatRoom> getAllActiveChatRooms() {
+        return chatRoomRepository.findByIsActiveTrue();
+    }
+    
+    /**
+     * 두 지점 간의 거리 계산 (km)
+     */
+    private double calculateDistance(double lat1, double lng1, double lat2, double lng2) {
+        final double R = 6371; // 지구 반지름 (km)
+        
+        double latDistance = Math.toRadians(lat2 - lat1);
+        double lngDistance = Math.toRadians(lng2 - lng1);
+        
+        double a = Math.sin(latDistance / 2) * Math.sin(latDistance / 2)
+                + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
+                * Math.sin(lngDistance / 2) * Math.sin(lngDistance / 2);
+        
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        
+        return R * c;
+    }
+}

--- a/src/main/java/com/tripgg/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/tripgg/common/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -43,5 +44,12 @@ public class GlobalExceptionHandler {
         log.error("Runtime error occurred: ", ex);
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(ApiResponse.error(ex.getMessage()));
+    }
+    
+    @ExceptionHandler(NoHandlerFoundException.class)
+    public ResponseEntity<ApiResponse<String>> handleNoHandlerFoundException(NoHandlerFoundException ex) {
+        log.warn("No handler found for {} {}", ex.getHttpMethod(), ex.getRequestURL());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.error("요청한 리소스를 찾을 수 없습니다."));
     }
 }

--- a/src/main/resources/static/favicon.ico
+++ b/src/main/resources/static/favicon.ico
@@ -1,0 +1,2 @@
+# This is a placeholder favicon file
+# 실제 favicon.ico 파일로 교체하거나 삭제하세요

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -236,6 +236,18 @@
                     <a href="/auth/kakao/login" class="api-btn" target="_blank">GET /auth/kakao/login</a>
                     <a href="/auth/kakao/url" class="api-btn" target="_blank">GET /auth/kakao/url</a>
                 </div>
+                
+                <div class="api-group">
+                    <h3>💬 채팅</h3>
+                    <a href="/api/chat/rooms" class="api-btn" target="_blank">GET /api/chat/rooms (모든 채팅방)</a>
+                    <a href="/api/chat/1?latitude=37.482052612221445&longitude=126.87966753395074" class="api-btn" target="_blank">GET /api/chat/1 (서울 사용자 - 서울 채팅방)</a>
+                    <a href="/api/chat/1?latitude=35.50203443657561&longitude=128.76076097099724" class="api-btn" target="_blank">GET /api/chat/1 (부산 사용자 - 서울 채팅방) ❌</a>
+                    <a href="/api/chat/2?latitude=35.50203443657561&longitude=128.76076097099724" class="api-btn" target="_blank">GET /api/chat/2 (부산 사용자 - 부산 채팅방)</a>
+                    <a href="/api/chat/1/messages?latitude=37.482052612221445&longitude=126.87966753395074" class="api-btn" target="_blank">GET /api/chat/1/messages (서울 사용자)</a>
+                    <a href="/api/chat/1/messages?latitude=35.50203443657561&longitude=128.76076097099724" class="api-btn" target="_blank">GET /api/chat/1/messages (부산 사용자) ❌</a>
+                    <button onclick="createSeoulChatRoom()" class="api-btn">POST /api/chat/room/create (서울 채팅방 생성)</button>
+                    <button onclick="createBusanChatRoom()" class="api-btn">POST /api/chat/room/create (부산 채팅방 생성)</button>
+                </div>
             </div>
         </div>
     </div>
@@ -294,6 +306,62 @@
         window.onload = function() {
             setTimeout(testAPI, 1000);
         };
+        
+        // 서울 채팅방 생성
+        async function createSeoulChatRoom() {
+            try {
+                const response = await fetch('/api/chat/room/create', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded',
+                    },
+                    body: new URLSearchParams({
+                        roomName: '서울 채팅방',
+                        latitude: '37.482052612221445',
+                        longitude: '126.87966753395074',
+                        locationName: '서울',
+                        radiusKm: '50'
+                    })
+                });
+                
+                const data = await response.json();
+                if (response.ok) {
+                    alert('✅ 서울 채팅방 생성 성공!\n' + JSON.stringify(data, null, 2));
+                } else {
+                    alert('❌ 서울 채팅방 생성 실패: ' + data.message);
+                }
+            } catch (error) {
+                alert('❌ 오류: ' + error.message);
+            }
+        }
+        
+        // 부산 채팅방 생성
+        async function createBusanChatRoom() {
+            try {
+                const response = await fetch('/api/chat/room/create', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded',
+                    },
+                    body: new URLSearchParams({
+                        roomName: '부산 채팅방',
+                        latitude: '35.50203443657561',
+                        longitude: '128.76076097099724',
+                        locationName: '부산',
+                        radiusKm: '50'
+                    })
+                });
+                
+                const data = await response.json();
+                if (response.ok) {
+                    alert('✅ 부산 채팅방 생성 성공!\n' + JSON.stringify(data, null, 2));
+                } else {
+                    alert('❌ 부산 채팅방 생성 실패: ' + data.message);
+                }
+            } catch (error) {
+                alert('❌ 오류: ' + error.message);
+            }
+        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
- Adds ChatRoom entity for separate chat rooms by region
- Users can only access chat rooms in their location
- Seoul users → Seoul chat room only
- Busan users → Busan chat room only

## How to test
1. Create Seoul and Busan chat rooms using buttons
2. Test access with different coordinates
3. Seoul coordinates: 37.482052612221445, 126.87966753395074
4. Busan coordinates: 35.50203443657561, 128.76076097099724

## API endpoints
- `GET /api/chat/{roomId}` - Check chat room access
- `GET /api/chat/{roomId}/messages` - Get messages
- `POST /api/chat/{roomId}/messages/send` - Send message